### PR TITLE
Updated README with install and usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import config from '../config/environment';
 
 *Note: The config import statement is a relative path.*
 
-Now you can make sure any issues are tracked against the correct git revision!
+**Now you can make sure any issues are tracked against the correct git revision!**
 
 ## Installation
 


### PR DESCRIPTION
Updated README with install and usage info. Let me know if I've left any key pieces out.

Unless I'm mistaken, I don't see a way to grab branch info, just the short sha.

If I'm correct, I was thinking about adding that in.

I was also thinking it might be nice to have a numeric version number, something that could easily be called out by a client in addition to the hash.

I was looking at: git rev-list --count HEAD

What do you think?
