### PR TITLE
disable log to console in test env

### DIFF
--- a/app/initializers/print-git-info.js
+++ b/app/initializers/print-git-info.js
@@ -4,6 +4,8 @@ export default {
   name: 'print-git-info',
 
   initialize: function() {
-    console.log(config.currentRevision);
+    if(config.environment !== 'test') {
+      console.log(config.currentRevision);
+    }
   }
 }


### PR DESCRIPTION
The console window gets cluttered with messages, if there are many
acceptance tests.
