### PR TITLE
Adds ember-cli-babel to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "git-repo-info": "^1.0.2"
+    "git-repo-info": "^1.0.2",
+    "ember-cli-babel":  "^6.6.0"
   }
 }


### PR DESCRIPTION
Fixes deprecation warning with `ember-cli@2.14.0`

```
DEPRECATION: Addon files were detected in `/Volumes/Source/proj/node_modules/ember-git-version/addon`, but no JavaScript preprocessors were found for `ember-git-version`. Please make sure to add a preprocessor (most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in `ember-git-version`'s `package.json`.
```